### PR TITLE
Update backend/cloud skills list

### DIFF
--- a/src/components/resume/download-resume-button.tsx
+++ b/src/components/resume/download-resume-button.tsx
@@ -273,6 +273,13 @@ export function DownloadResumeButton() {
 		addText(langText, margin + labelWidth, y, { fontSize: 9, color: mutedForeground })
 		y += 8
 
+		checkPageBreak(6)
+		addText('* = experimenting / learning', margin, y, {
+			fontSize: 8,
+			color: mutedForeground
+		})
+		y += 8
+
 		addSectionHeader('Projects')
 
 		resumeData.projects.forEach((project) => {

--- a/src/components/resume/download-resume-button.tsx
+++ b/src/components/resume/download-resume-button.tsx
@@ -273,7 +273,7 @@ export function DownloadResumeButton() {
 		addText(langText, margin + labelWidth, y, { fontSize: 9, color: mutedForeground })
 		y += 8
 
-		checkPageBreak(6)
+		checkPageBreak(8)
 		addText('* = experimenting / learning', margin, y, {
 			fontSize: 8,
 			color: mutedForeground

--- a/src/lib/resume-data.ts
+++ b/src/lib/resume-data.ts
@@ -161,9 +161,21 @@ export const resumeData: Resume = {
 			'Shell (bash, fish, zsh)',
 			'Scripting (Python*, Lua)'
 		],
-		frameworks: ['React', 'Next.js', 'TanStack Start', 'SolidStart*', 'Qwik*', 'Svelte*'],
+		frameworks: ['React', 'Next.js', 'TanStack Start', 'Solid', 'Qwik*', 'Svelte*'],
 		styling: ['CSS', 'SCSS/Less/Sass', 'Styled Components', 'Tailwind CSS'],
-		backend: ['Node.js', 'Hono', 'ElysiaJS', 'Express', 'Go*', 'Tauri/Rust*'],
+		backend: [
+			'Node.js',
+			'Hono*',
+			'Elysia*',
+			'Express',
+			'React Server Components (RSC)',
+			'Next.js Server Actions / Route Handlers',
+			'SSR (Server-Side Rendering)',
+			'Serverless & Edge runtimes (Vercel, Cloudflare Workers)',
+			'BFF (Backend for Frontend)',
+			'Go*',
+			'Tauri/Rust*'
+		],
 		databases: ['PostgreSQL', 'SQLite', 'LibSQL', 'Turso', 'Drizzle ORM', 'Prisma'],
 		tools: ['Git', 'Docker', 'Vite', 'pnpm', 'Bun', 'Linux', 'SSH', 'CLI/DX tooling'],
 		design: ['Figma', 'Photoshop'],


### PR DESCRIPTION
Updates backend/cloud skills to reflect RSC, Server Actions, SSR, serverless/edge runtimes, and BFF. Also adds PDF legend for learning/experimental skills.

## Summary by Sourcery

Update resume data to reflect additional backend and cloud-related skills and clarify the legend for learning/experimental skills in the generated PDF resume.

New Features:
- Add detailed backend and cloud skills such as React Server Components, Next.js Server Actions, SSR, serverless/edge runtimes, and BFF to the resume data.
- Add a PDF legend entry explaining the asterisk marker for experimenting/learning skills.

Enhancements:
- Adjust frontend framework listing in resume data to treat Solid as a primary framework rather than an experimental one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the resume’s backend and framework listings to include broader server-side patterns, serverless/edge runtimes, and modern architectures.
  * Added a clarifying footnote indicating "*" denotes experimental/learning items, placed visibly before the Projects section to improve layout and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->