### PR TITLE
feat: integrate @remcostoeten/analytics with root tracking and download event

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
-        "@remcostoeten/analytics": "^1.2.0",
+        "@remcostoeten/analytics": "^1.3.0",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
-        "@vercel/analytics": "^1.6.0",
+        "@remcostoeten/analytics": "^1.2.0",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type React from "react"
 import type { Metadata, Viewport } from "next"
-import { Analytics } from "@vercel/analytics/next"
+import { Analytics } from "@/components/analytics"
 import "@/styles/globals.css"
 
 // Structured data for SEO
@@ -169,8 +169,6 @@ export default function RootLayout({
             <body className="py-12 font-helvetica antialiased">
                 {children}
                 <Analytics />
-                {/* Uncomment below and add your GA4 measurement ID to analytics.tsx */}
-                {/* <GoogleAnalytics /> */}
             </body>
         </html>
     )

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -1,44 +1,40 @@
 'use client'
 
-import { useEffect } from 'react'
+import {
+    Analytics as RemcoAnalytics,
+    type EventMeta,
+    type EventName,
+    type EventPayload
+} from '@remcostoeten/analytics'
+import * as RemcoSdk from '@remcostoeten/analytics'
 
-// Google Analytics - Uses environment variable
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID
+type TrackFunc = (
+    name: EventName,
+    payload?: EventPayload,
+    meta?: EventMeta
+) => void
 
-export function GoogleAnalytics() {
-	useEffect(() => {
-		// Only load GA in production and if ID is configured
-		if (
-			process.env.NODE_ENV === 'production' &&
-			GA_MEASUREMENT_ID &&
-			GA_MEASUREMENT_ID !== 'G-XXXXXXXXXX'
-		) {
-			// Load gtag.js script
-			const script = document.createElement('script')
-			script.async = true
-			script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
-			document.head.appendChild(script)
+function getTrack(): TrackFunc | null {
+    if ('track' in RemcoSdk && typeof RemcoSdk.track === 'function') {
+        return RemcoSdk.track as TrackFunc
+    }
 
-			// Initialize gtag
-			window.dataLayer = window.dataLayer || []
-			window.gtag = function gtag() {
-				window.dataLayer.push(arguments)
-			}
-			window.gtag('js', new Date())
-			window.gtag('config', GA_MEASUREMENT_ID, {
-				page_title: document.title,
-				page_location: window.location.href
-			})
-		}
-	}, [])
-
-	return null
+    return null
 }
 
-// TypeScript declarations for gtag
-declare global {
-	interface Window {
-		dataLayer: any[]
-		gtag: (...args: any[]) => void
-	}
+export function trackEvent(name: EventName, payload?: EventPayload, meta?: EventMeta) {
+    const track = getTrack()
+
+    if (track) {
+        track(name, payload, meta)
+    }
+}
+
+export function Analytics() {
+    return (
+        <RemcoAnalytics
+            projectId="resume-20226"
+            ingestUrl="https://ingestion.remcostoeten.nl"
+        />
+    )
 }

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import {
-    Analytics as RemcoAnalytics,
-    type EventMeta,
-    type EventName,
-    type EventPayload
-} from '@remcostoeten/analytics'
 import * as RemcoSdk from '@remcostoeten/analytics'
+
+type EventMeta = RemcoSdk.EventMeta
+
+type EventName = RemcoSdk.EventName
+
+type EventPayload = RemcoSdk.EventPayload
 
 type TrackFunc = (
     name: EventName,
@@ -14,27 +14,41 @@ type TrackFunc = (
     meta?: EventMeta
 ) => void
 
+let trackRef: TrackFunc | null | undefined
+
 function getTrack(): TrackFunc | null {
-    if ('track' in RemcoSdk && typeof RemcoSdk.track === 'function') {
-        return RemcoSdk.track as TrackFunc
+    if (trackRef !== undefined) {
+        return trackRef
     }
 
+    if ('track' in RemcoSdk && typeof RemcoSdk.track === 'function') {
+        trackRef = RemcoSdk.track as TrackFunc
+        return trackRef
+    }
+
+    trackRef = null
     return null
 }
 
 export function trackEvent(name: EventName, payload?: EventPayload, meta?: EventMeta) {
     const track = getTrack()
 
-    if (track) {
+    if (!track) {
+        return
+    }
+
+    try {
         track(name, payload, meta)
+    } catch (error) {
+        console.error('analytics_track_error', error)
     }
 }
 
 export function Analytics() {
-    return (
-        <RemcoAnalytics
-            projectId="resume-20226"
-            ingestUrl="https://ingestion.remcostoeten.nl"
-        />
-    )
+    const projectId = process.env.NEXT_PUBLIC_ANALYTICS_PROJECT_ID ?? 'resume-2026'
+    const ingestUrl =
+        process.env.NEXT_PUBLIC_ANALYTICS_INGEST_URL ??
+        'https://ingestion.remcostoeten.nl'
+
+    return <RemcoSdk.Analytics projectId={projectId} ingestUrl={ingestUrl} />
 }

--- a/src/components/resume/download-resume-button.tsx
+++ b/src/components/resume/download-resume-button.tsx
@@ -347,10 +347,14 @@ export function DownloadResumeButton() {
 
 		// Save
 		doc.save('remco-stoeten-frontend-engineer-resume.pdf')
-		trackEvent('resume_download', {
-			fileName: 'remco-stoeten-frontend-engineer-resume.pdf',
-			location: 'resume_page'
-		})
+		try {
+			trackEvent('resume_download', {
+				fileName: 'remco-stoeten-frontend-engineer-resume.pdf',
+				location: 'resume_page'
+			})
+		} catch (error) {
+			console.error('resume_download_track_error', error)
+		}
 	}
 
 	return (

--- a/src/components/resume/download-resume-button.tsx
+++ b/src/components/resume/download-resume-button.tsx
@@ -3,6 +3,7 @@
 import { Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { resumeData } from '@/lib/resume-data'
+import { trackEvent } from '@/components/analytics'
 
 // Helper function to parse bold markdown and return segments for PDF
 function parseBoldForPDF(text: string): Array<{ text: string; bold: boolean }> {
@@ -346,6 +347,10 @@ export function DownloadResumeButton() {
 
 		// Save
 		doc.save('remco-stoeten-frontend-engineer-resume.pdf')
+		trackEvent('resume_download', {
+			fileName: 'remco-stoeten-frontend-engineer-resume.pdf',
+			location: 'resume_page'
+		})
 	}
 
 	return (


### PR DESCRIPTION
### Motivation
- Add the `@remcostoeten/analytics` SDK and mount analytics at the application root so page views are tracked via a single `<Analytics/>` component. 
- Provide a small, reusable API to emit custom events (e.g. resume downloads) and configure ingestion to `https://ingestion.remcostoeten.nl` for the `resume-20226` project.

### Description
- Added `@remcostoeten/analytics` to `package.json` (replacing `@vercel/analytics`) as `^1.2.0`.
- Implemented `src/components/analytics.tsx` which exports an `Analytics` component that renders the SDK with `projectId="resume-20226"` and `ingestUrl="https://ingestion.remcostoeten.nl"`, and a `trackEvent(...)` helper that forwards events when the SDK exposes `track`.
- Replaced the Vercel analytics import in `src/app/layout.tsx` to import the local `Analytics` component and mounted it at the root so page views are recorded automatically.
- Instrumented `src/components/resume/download-resume-button.tsx` to call `trackEvent('resume_download', { fileName, location })` immediately after `doc.save(...)` to capture resume download events.

### Testing
- Attempted `npm install` to validate the dependency but install failed due to the registry returning `403 Forbidden` for `@remcostoeten/analytics`, so package resolution could not be verified in this environment. (failed)
- Ran `npm run format:fix` but `oxfmt` was not available in the environment because dependencies could not be installed, so formatting could not be executed here. (failed)
- Application-level changes were compiled and persisted to the repository and committed, but runtime verification of the SDK integration requires a network-enabled environment where `@remcostoeten/analytics` can be installed. (manual verification required)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cdd0e8808327a9c4448a9a3f5282)

## Summary by Sourcery

Integrate the @remcostoeten/analytics SDK as the root analytics provider and add tracking for resume downloads.

New Features:
- Add a reusable Analytics component configured for the resume-20226 project with ingestion to the Remco analytics endpoint.
- Expose a trackEvent helper to emit custom analytics events from components.
- Track resume download events from the resume download button with relevant metadata.

Enhancements:
- Replace the previous Google and Vercel analytics setup with the new @remcostoeten/analytics integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics infrastructure for improved event tracking and reliability.
  * Enhanced resume download tracking to capture user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->